### PR TITLE
Fix spinner spacing

### DIFF
--- a/louis-blog/src/App.jsx
+++ b/louis-blog/src/App.jsx
@@ -30,7 +30,7 @@ const App = () => {
       <div className="flex flex-col min-h-screen">
         <Navbar />
         <main className="flex-grow container mx-auto p-4">
-          <Suspense fallback={<div>Loading...</div>}>
+          <Suspense fallback={<div className="mt-8">Loading...</div>}>
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/cv" element={<CvViewer />} />


### PR DESCRIPTION
## Summary
- add margin above the loading spinner shown when pages reload

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684720683750832089375043ab05d483