### PR TITLE
Add basic SEO metadata

### DIFF
--- a/louis-blog/index.html
+++ b/louis-blog/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/webp" href="/logo_favicon_white_blue.webp" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Louis Paulet Blog</title>
+    <meta name="description" content="Data science articles, projects, and personal updates from Louis Paulet" />
+    <meta property="og:title" content="Louis Paulet Blog" />
+    <meta property="og:description" content="Data science articles, projects, and personal updates from Louis Paulet" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add meta description and OpenGraph fields to blog index HTML

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6849e642dfb48320851c03a3e094614c