### PR TITLE
Fix stale post content during route changes

### DIFF
--- a/louis-blog/src/components/Post.jsx
+++ b/louis-blog/src/components/Post.jsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm'
 import postData from './../PostData';
 import SocialLinks from './../components/SocialLinks'
 import NotFound from '../pages/NotFound'
+import { loadPostContent } from './postContent';
 
 const stripLeadingHeading = (markdown) =>
   markdown.replace(/^\s{0,3}#{1,6}\s+.*(?:\r?\n)+/, '');
@@ -13,24 +14,47 @@ const Post = () => {
   const { postId } = useParams();
   const [content, setContent] = useState('');
   const [loadError, setLoadError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const postMeta = postData.find((post) => post.id === postId);
 
   useEffect(() => {
-    fetch(`${import.meta.env.BASE_URL}posts/${postId}.md`)
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error('Failed to fetch');
-        }
-        return res.text();
-      })
+    const controller = new AbortController();
+    let isCurrentRequest = true;
+
+    setContent('');
+    setLoadError(false);
+    setIsLoading(true);
+
+    loadPostContent({
+      baseUrl: import.meta.env.BASE_URL,
+      postId,
+      signal: controller.signal,
+    })
       .then((text) => {
+        if (!isCurrentRequest) {
+          return;
+        }
+
         setContent(text);
-        setLoadError(false);
       })
       .catch((err) => {
+        if (!isCurrentRequest || err.name === 'AbortError') {
+          return;
+        }
+
         console.error(err);
         setLoadError(true);
+      })
+      .finally(() => {
+        if (isCurrentRequest) {
+          setIsLoading(false);
+        }
       });
+
+    return () => {
+      isCurrentRequest = false;
+      controller.abort();
+    };
   }, [postId]);
 
   if (loadError) {
@@ -68,12 +92,16 @@ const Post = () => {
           </div>
         )}
         <div className="min-w-0 p-5 sm:p-10">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            className="prose prose-base prose-light min-w-0 max-w-none leading-relaxed prose-img:mx-auto prose-img:w-full prose-pre:max-w-full prose-pre:overflow-x-auto sm:prose-lg sm:leading-relaxed sm:prose-h1:text-4xl sm:prose-h2:text-3xl sm:prose-h3:text-2xl prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl"
-          >
-            {renderedContent}
-          </ReactMarkdown>
+          {isLoading ? (
+            <p className="text-sm text-secondary" role="status">Loading post…</p>
+          ) : (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              className="prose prose-base prose-light min-w-0 max-w-none leading-relaxed prose-img:mx-auto prose-img:w-full prose-pre:max-w-full prose-pre:overflow-x-auto sm:prose-lg sm:leading-relaxed sm:prose-h1:text-4xl sm:prose-h2:text-3xl sm:prose-h3:text-2xl prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl"
+            >
+              {renderedContent}
+            </ReactMarkdown>
+          )}
         </div>
       </div>
       <div className="min-w-0 border border-soft bg-surface p-5 shadow-[12px_12px_24px_rgba(185,194,212,0.45),-12px_-12px_24px_rgba(255,255,255,0.95)] sm:p-8">

--- a/louis-blog/src/components/postContent.js
+++ b/louis-blog/src/components/postContent.js
@@ -1,0 +1,12 @@
+export const loadPostContent = async ({ baseUrl, postId, signal, fetchImpl = fetch }) => {
+  const response = await fetchImpl(
+    `${baseUrl}posts/${encodeURIComponent(postId)}.md`,
+    { signal },
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  return response.text();
+};

--- a/louis-blog/tests/post-content.test.mjs
+++ b/louis-blog/tests/post-content.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { loadPostContent } from '../src/components/postContent.js';
+
+test('post content requests encode the route id and forward cancellation', async () => {
+  const signal = { aborted: false };
+  let request;
+
+  const content = await loadPostContent({
+    baseUrl: './',
+    postId: 'post/14',
+    signal,
+    fetchImpl: async (...args) => {
+      request = args;
+      return {
+        ok: true,
+        text: async () => '# Post 14',
+      };
+    },
+  });
+
+  assert.equal(request[0], './posts/post%2F14.md');
+  assert.deepEqual(request[1], { signal });
+  assert.equal(content, '# Post 14');
+});
+
+test('post content requests surface failed responses', async () => {
+  await assert.rejects(
+    loadPostContent({
+      baseUrl: './',
+      postId: 'missing',
+      fetchImpl: async () => ({ ok: false }),
+    }),
+    { message: 'Failed to fetch' },
+  );
+});


### PR DESCRIPTION
## What changed

- cancel in-flight Markdown requests when navigating between post routes
- ignore responses from stale requests
- clear the previous article and show a loading status during transitions
- encode post IDs and add focused loader regression tests

## Bug fixed

React Router reuses the post component for `/posts/:postId`. Previously, a slow response from the previous route could overwrite the current article, leaving the URL and displayed content out of sync.

## Verification

- `npm --prefix louis-blog run lint`
- `npm --prefix louis-blog test`
- `npm --prefix louis-blog run build`
- browser verification of post reload and post14 → post13 navigation