### PR TITLE
Fix mobile navigation menu dismissal

### DIFF
--- a/louis-blog/src/components/Navbar.jsx
+++ b/louis-blog/src/components/Navbar.jsx
@@ -61,6 +61,8 @@ const Navbar = () => {
   }, []);
 
   const handleLogoClick = (event) => {
+    setIsMobileMenuOpen(false);
+
     if (!isHomePage || typeof window === 'undefined') {
       return;
     }
@@ -129,7 +131,13 @@ const Navbar = () => {
           <div id="mobile-primary-navigation" className="grid pb-4 md:hidden">
             <div className="grid gap-2 border-t border-soft pt-3">
               {navItems.map(([to, label]) => (
-                <NavLink key={to} to={to} end={to === '/'} className={mobileLinkClasses}>
+                <NavLink
+                  key={to}
+                  to={to}
+                  end={to === '/'}
+                  className={mobileLinkClasses}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
                   <span className="min-w-0">{label}</span>
                   <FaArrowRight aria-hidden="true" className="flex-shrink-0 text-accent" />
                 </NavLink>


### PR DESCRIPTION
## Summary
- close the mobile menu when any mobile navigation link is selected
- close the mobile menu when the logo is clicked, including when already on the home route

## Bug fixed
Selecting the already-active mobile route did not change the pathname, so the existing route-change effect never ran and the menu remained open.

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Browser check at 320px: active-route and route-change selections both close the menu.