### PR TITLE
Respect analytics consent before tracking pageviews

### DIFF
--- a/louis-blog/src/components/ConsentBanner.jsx
+++ b/louis-blog/src/components/ConsentBanner.jsx
@@ -1,24 +1,41 @@
 import { useState, useEffect } from 'react';
 import ReactGA from 'react-ga4';
+import { CONSENT_UPDATED_EVENT } from './analyticsConsent';
 
 const ConsentBanner = () => {
   const [consentGiven, setConsentGiven] = useState(true);
 
   useEffect(() => {
-    const storedConsent = localStorage.getItem('ga_consent');
-    if (!storedConsent) {
+    try {
+      const storedConsent = window.localStorage?.getItem('ga_consent');
+      if (!storedConsent) {
+        setConsentGiven(false);
+      }
+    } catch (error) {
+      console.warn('Unable to read analytics consent from storage.', error);
       setConsentGiven(false);
     }
   }, []);
 
   const handleConsent = (consent) => {
-    ReactGA.gtag("consent", "update", {
-      ad_storage: consent.ad_storage,
-      ad_user_data: consent.ad_user_data,
-      ad_personalization: consent.ad_personalization,
-      analytics_storage: consent.analytics_storage,
-    });
-    localStorage.setItem('ga_consent', JSON.stringify(consent));
+    try {
+      ReactGA.gtag("consent", "update", {
+        ad_storage: consent.ad_storage,
+        ad_user_data: consent.ad_user_data,
+        ad_personalization: consent.ad_personalization,
+        analytics_storage: consent.analytics_storage,
+      });
+    } catch (error) {
+      console.warn('Failed to update analytics consent.', error);
+    }
+
+    try {
+      window.localStorage?.setItem('ga_consent', JSON.stringify(consent));
+    } catch (error) {
+      console.warn('Unable to save analytics consent to storage.', error);
+    }
+
+    window.dispatchEvent(new Event(CONSENT_UPDATED_EVENT));
     setConsentGiven(true);
   };
 
@@ -34,7 +51,7 @@ const ConsentBanner = () => {
   const acceptMinimum = () => {
     handleConsent({
       ad_storage: "denied",
-      ad_user_data: "granted",
+      ad_user_data: "denied",
       ad_personalization: "denied",
       analytics_storage: "granted",
     });

--- a/louis-blog/src/components/analyticsConsent.js
+++ b/louis-blog/src/components/analyticsConsent.js
@@ -1,0 +1,3 @@
+export const CONSENT_UPDATED_EVENT = 'ga-consent-updated';
+
+export const hasAnalyticsConsent = (consent) => consent?.analytics_storage === 'granted';

--- a/louis-blog/src/components/usePageAnalytics.js
+++ b/louis-blog/src/components/usePageAnalytics.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import ReactGA from "react-ga4";
+import { CONSENT_UPDATED_EVENT, hasAnalyticsConsent } from "./analyticsConsent";
 
 const TRACKING_ID = "G-1XEGFVZDME";
 
@@ -66,29 +67,34 @@ const sendPageview = (location) => {
 const usePageAnalytics = () => {
   const location = useLocation();
   const [isGAInitialized, setIsGAInitialized] = useState(false);
+  const [consent, setConsent] = useState(getStoredConsent);
 
   useEffect(() => {
     setIsGAInitialized(initializeAnalytics());
   }, []);
 
   useEffect(() => {
-    if (!isGAInitialized) {
+    const handleConsentUpdate = () => setConsent(getStoredConsent());
+
+    window.addEventListener(CONSENT_UPDATED_EVENT, handleConsentUpdate);
+    return () => window.removeEventListener(CONSENT_UPDATED_EVENT, handleConsentUpdate);
+  }, []);
+
+  useEffect(() => {
+    if (!isGAInitialized || !consent) {
       return;
     }
 
-    const storedConsent = getStoredConsent();
-    if (storedConsent) {
-      updateConsent(storedConsent);
-    }
-  }, [isGAInitialized]);
+    updateConsent(consent);
+  }, [consent, isGAInitialized]);
 
   useEffect(() => {
-    if (!isGAInitialized) {
+    if (!isGAInitialized || !hasAnalyticsConsent(consent)) {
       return;
     }
 
     sendPageview(location);
-  }, [location, isGAInitialized]);
+  }, [consent, isGAInitialized, location]);
 };
 
 export default usePageAnalytics;

--- a/louis-blog/tests/analytics-consent.test.mjs
+++ b/louis-blog/tests/analytics-consent.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { hasAnalyticsConsent } from '../src/components/analyticsConsent.js';
+
+test('pageviews require explicit analytics consent', () => {
+  assert.equal(hasAnalyticsConsent(null), false);
+  assert.equal(hasAnalyticsConsent({}), false);
+  assert.equal(hasAnalyticsConsent({ analytics_storage: 'denied' }), false);
+  assert.equal(hasAnalyticsConsent({ analytics_storage: 'granted' }), true);
+});


### PR DESCRIPTION
## Summary

- prevent pageview events before explicit analytics consent
- react immediately when a visitor chooses an analytics preference
- make the minimal analytics option deny ad user data
- keep the consent banner usable when localStorage is unavailable

## Verification

- `npm test`
- `npm run lint`
- `npm run build`